### PR TITLE
Fix Programmatic Dismissal

### DIFF
--- a/Example/BottomSheetExample/Main/ExampleBottomSheet/ExampleBottomSheetView.swift
+++ b/Example/BottomSheetExample/Main/ExampleBottomSheet/ExampleBottomSheetView.swift
@@ -15,6 +15,10 @@ final class ExampleBottomSheetView: UIView {
   
   let button = UIButton(type: .system)
     
+  // MARK: - Interactions
+  
+  var didTapButton: (() -> Void)?
+  
   // MARK: - Init
   
   override init(frame: CGRect) {
@@ -35,6 +39,11 @@ final class ExampleBottomSheetView: UIView {
     addSubview(titleLabel)
     addSubview(descriptionLabel)
     addSubview(button)
+    
+    let action = UIAction { [weak self] _ in
+      self?.didTapButton?()
+    }
+    button.addAction(action, for: .touchUpInside)
   }
   
   private func style() {
@@ -106,14 +115,14 @@ extension ExampleBottomSheetView {
   static func styleButton(_ button: UIButton) {
     if #available(iOS 15, *) {
       var configuration = UIButton.Configuration.borderedProminent()
-      configuration.title = "Download"
+      configuration.title = "Dismiss"
       configuration.contentInsets = NSDirectionalEdgeInsets(top: 16, leading: 16, bottom: 16, trailing: 16)
       configuration.baseBackgroundColor = .systemOrange
       configuration.cornerStyle = .medium
       button.configuration = configuration
     } else {
       button.backgroundColor = .systemOrange
-      button.setTitle("Download", for: .normal)
+      button.setTitle("Dismiss", for: .normal)
       button.titleLabel?.font = .preferredFont(forTextStyle: .headline)
       button.setTitleColor(.white, for: .normal)
       button.titleEdgeInsets = UIEdgeInsets(top: 12, left: 12, bottom: 12, right: 12)

--- a/Example/BottomSheetExample/Main/ExampleBottomSheet/ExampleBottomSheetViewController.swift
+++ b/Example/BottomSheetExample/Main/ExampleBottomSheet/ExampleBottomSheetViewController.swift
@@ -6,9 +6,21 @@ import UIKit
 
 final class ExampleBottomSheetViewController: UIViewController {
   
+  var rootView: ExampleBottomSheetView? {
+    view as? ExampleBottomSheetView
+  }
+  
   // MARK: - Lifecycle
   
   override func loadView() {
     view = ExampleBottomSheetView()
+  }
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    
+    rootView?.didTapButton = { [weak self] in
+      self?.dismiss(animated: true)
+    }
   }
 }

--- a/Sources/BottomSheet/SheetPresentationController.swift
+++ b/Sources/BottomSheet/SheetPresentationController.swift
@@ -190,7 +190,6 @@ final class SheetPresentationController: UIPresentationController {
   /// Triggers the dismiss transition in an interactive manner.
   /// - Parameter isInteractive: Whether the transition should be started interactively by the user.
   private func dismiss(interactively isInteractive: Bool) {
-    transitioningDelegate?.transition.isPresenting = false
     transitioningDelegate?.transition.wantsInteractiveStart = isInteractive
     presentedViewController.dismiss(animated: true)
   }

--- a/Sources/BottomSheet/SheetTransitioningDelegate.swift
+++ b/Sources/BottomSheet/SheetTransitioningDelegate.swift
@@ -32,10 +32,12 @@ public final class SheetTransitioningDelegate: NSObject, UIViewControllerTransit
   }
   
   public func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
-    transition
+    transition.isPresenting = false
+    return transition
   }
   
   public func interactionControllerForDismissal(using animator: UIViewControllerAnimatedTransitioning) -> UIViewControllerInteractiveTransitioning? {
-    transition
+    transition.isPresenting = false
+    return transition
   }
 }


### PR DESCRIPTION
### Description
This PR fixes the programmatic dismissal of sheets.

### Motivation and Context
The transition object keeps track of whether the transition is being used for prevention or dismissal of a view controller. The `isPresenting` value was previously only toggled when dismissing the sheet interactively. Now this value is being toggled correctly in the transitioning delegate.